### PR TITLE
Add `detection_window` handling

### DIFF
--- a/difi/cifi.py
+++ b/difi/cifi.py
@@ -159,16 +159,16 @@ def analyzeObservations(observations,
     # get the metric function
     metric_func = metric if callable(metric) else metric_func_mapper[metric]
 
-    # if user wants to use a detection window and there are more nights than the window length
+    # if user wants to use a detection window
     detected_truths = np.array([])
-    if detection_window is not None and len(night_range) > detection_window:
+    if detection_window is not None:
         all_findable_observations = []
 
         # loop over potential detection windows
-        for i in range(night_range[0], night_range[0] + len(night_range) - detection_window + 1):
+        for night in night_range:
             # mask observations to just this window
-            win_obs = observations[((observations[column_mapping["night"]] >= i)
-                                  & (observations[column_mapping["night"]] <= i + detection_window))]
+            win_obs = observations[((observations[column_mapping["night"]] >= night)
+                                  & (observations[column_mapping["night"]] < night + detection_window))]
 
             # if ignoring previous detections then mask them out as well
             if ignore_after_detected and len(detected_truths) > 0:
@@ -185,7 +185,7 @@ def analyzeObservations(observations,
                 detected_truths = np.concatenate([detected_truths, window_detected_truths])
 
             # add a column recording in which window this object was detected
-            window_findable_observations["window_start_night"] = i
+            window_findable_observations["window_start_night"] = night
             all_findable_observations.append(window_findable_observations)
 
         # combine the findable observations tables

--- a/difi/metrics.py
+++ b/difi/metrics.py
@@ -89,7 +89,8 @@ def _findNightlyLinkages(object_observations,
 def calcFindableNightlyLinkages(observations, 
                                 linkage_min_obs=2, 
                                 max_obs_separation=1.5/24, 
-                                min_linkage_nights=3, 
+                                min_linkage_nights=3,
+                                detection_window=15,
                                 column_mapping={"obs_id" : "obs_id", 
                                                 "truth" : "truth",
                                                 "time" : "time", 
@@ -113,6 +114,8 @@ def calcFindableNightlyLinkages(observations,
         to be considered to be in a linkage (in the same units of decimal days).
     min_linkage_nights : int, optional
         Minimum number of nights on which a linkage should appear.
+    detection_window : int, optional
+        Number of nights in the detection window in which a minimum of `min_linkage_nights` must occur
     column_mapping : dict, optional
         The mapping of columns in observations to internally used names. 
         Needs the following: "truth": ..., "obs_id" : ..., "time" : ..., "night" : ... .
@@ -149,6 +152,7 @@ def calcFindableNightlyLinkages(observations,
             linkage_min_obs=linkage_min_obs,
             max_obs_separation=max_obs_separation, 
             min_linkage_nights=min_linkage_nights,
+            detection_window=detection_window,
             column_mapping=column_mapping
         ).to_frame(name="obs_ids")
 

--- a/difi/metrics.py
+++ b/difi/metrics.py
@@ -11,7 +11,6 @@ def _findNightlyLinkages(object_observations,
                          linkage_min_obs=2,
                          max_obs_separation=1.5/24, 
                          min_linkage_nights=3,
-                         detection_window=15,
                          column_mapping={"obs_id" : "obs_id", 
                                          "time" : "time",
                                          "night" : "night"}):
@@ -33,8 +32,6 @@ def _findNightlyLinkages(object_observations,
         Maximum timespan between two observations. 
     min_linkage_nights : int, optional
         Minimum number of nights on which a linkage should appear.
-    detection_window : int, optional
-        Number of nights in the detection window in which a minimum of `min_linkage_nights` must occur
     column_mapping : dict, optional
         The mapping of columns in observations to internally used names. 
         Needs the following: obs_id" : ..., "time" : ... , "night" : ....
@@ -72,13 +69,7 @@ def _findNightlyLinkages(object_observations,
         # is still equal to or greater than the minimum number of nights.
         enough_nights = len(night_counts[night_counts >= linkage_min_obs]) >= min_linkage_nights
 
-        # ensure that the observations all occur within a detection window
-        diff_nights = np.diff(linkage_nights)
-        window_sizes = np.array([sum(diff_nights[i:i + min_linkage_nights - 1])
-                                for i in range(len(diff_nights) - min_linkage_nights + 2)])
-        within_window = any(window_sizes <= detection_window)
-
-        if not enough_obs or not enough_nights or not within_window:
+        if not enough_obs or not enough_nights:
             return np.array([])
 
     else:
@@ -90,7 +81,6 @@ def calcFindableNightlyLinkages(observations,
                                 linkage_min_obs=2, 
                                 max_obs_separation=1.5/24, 
                                 min_linkage_nights=3,
-                                detection_window=15,
                                 column_mapping={"obs_id" : "obs_id", 
                                                 "truth" : "truth",
                                                 "time" : "time", 
@@ -114,8 +104,6 @@ def calcFindableNightlyLinkages(observations,
         to be considered to be in a linkage (in the same units of decimal days).
     min_linkage_nights : int, optional
         Minimum number of nights on which a linkage should appear.
-    detection_window : int, optional
-        Number of nights in the detection window in which a minimum of `min_linkage_nights` must occur
     column_mapping : dict, optional
         The mapping of columns in observations to internally used names. 
         Needs the following: "truth": ..., "obs_id" : ..., "time" : ..., "night" : ... .
@@ -152,7 +140,6 @@ def calcFindableNightlyLinkages(observations,
             linkage_min_obs=linkage_min_obs,
             max_obs_separation=max_obs_separation, 
             min_linkage_nights=min_linkage_nights,
-            detection_window=detection_window,
             column_mapping=column_mapping
         ).to_frame(name="obs_ids")
 

--- a/difi/metrics.py
+++ b/difi/metrics.py
@@ -66,11 +66,11 @@ def _findNightlyLinkages(object_observations,
         linkage_nights, night_counts = np.unique(nights[np.isin(obs_ids, linkage_obs)], return_counts=True)
 
         # Make sure that the number of observations is still linkage_min_obs * min_linkage_nights
-        enough_obs = len(linkage_obs) < (linkage_min_obs * min_linkage_nights)
+        enough_obs = len(linkage_obs) >= (linkage_min_obs * min_linkage_nights)
 
         # Make sure that the number of unique nights on which a linkage is made
         # is still equal to or greater than the minimum number of nights.
-        enough_nights = len(night_counts[night_counts >= linkage_min_obs]) < min_linkage_nights
+        enough_nights = len(night_counts[night_counts >= linkage_min_obs]) >= min_linkage_nights
 
         # ensure that the observations all occur within a detection window
         diff_nights = np.diff(linkage_nights)

--- a/difi/utils.py
+++ b/difi/utils.py
@@ -7,7 +7,9 @@ __all__ = [
     "_checkColumnTypesEqual",
     "_classHandler",
     "_percentHandler",
-    "calcFirstFindableNight"
+    "calcFirstFindableNight",
+    "_firstFindableNightMinObs",
+    "_firstFindableNightNightlyLinkages"
 ]
 
 
@@ -214,12 +216,12 @@ def _percentHandler(number, number_total):
     return percent_total
 
 
-def firstFindableNightMinObs(obs_ids, observations,
-                             column_mapping={
-                                "obs_id": "obs_id",
-                                "night_id": "night_id"
-                             },
-                             min_obs=6):
+def _firstFindableNightMinObs(obs_ids, observations,
+                              column_mapping={
+                                 "obs_id": "obs_id",
+                                 "night_id": "night_id"
+                              },
+                              min_obs=6):
     """For a particular findable object, find the first night on which it
     becomes findable when requiring a minimum of `min_obs` observations.
 
@@ -245,13 +247,13 @@ def firstFindableNightMinObs(obs_ids, observations,
     return observations.loc[obs_ids[min_obs - 1]][column_mapping["night_id"]]
 
 
-def firstFindableNightNightlyLinkages(obs_ids, observations,
-                                      column_mapping={
-                                          "obs_id": "obs_id",
-                                          "night_id": "night_id"
-                                      },
-                                      min_linkage_nights=3,
-                                      detection_window=15):
+def _firstFindableNightNightlyLinkages(obs_ids, observations,
+                                       column_mapping={
+                                           "obs_id": "obs_id",
+                                           "night_id": "night_id"
+                                       },
+                                       min_linkage_nights=3,
+                                       detection_window=15):
     """For a particular findable object, find the first night on which it
     becomes findable when requiring a minimum of `min_linkage_nights`
     nights of linkages within a `detection_window` night range.
@@ -339,7 +341,7 @@ def calcFirstFindableNight(findable_obs, observations,
     TypeError : If the truth column in observations does not have type "Object"
     """
     if metric == "min_obs":
-        first_findable_night = findable_obs["obs_ids"].apply(firstFindableNightMinObs, observations=observations, column_mapping=column_mapping, **metric_kwargs)
+        first_findable_night = findable_obs["obs_ids"].apply(_firstFindableNightMinObs, observations=observations, column_mapping=column_mapping, **metric_kwargs)
     elif metric == "nightly_linkages":
-        first_findable_night = findable_obs["obs_ids"].apply(firstFindableNightNightlyLinkages, observations=observations, column_mapping=column_mapping, **metric_kwargs)
+        first_findable_night = findable_obs["obs_ids"].apply(_firstFindableNightNightlyLinkages, observations=observations, column_mapping=column_mapping, **metric_kwargs)
     return first_findable_night

--- a/difi/utils.py
+++ b/difi/utils.py
@@ -6,7 +6,8 @@ __all__ = [
     "_checkColumnTypes",
     "_checkColumnTypesEqual",
     "_classHandler",
-    "_percentHandler"
+    "_percentHandler",
+    "calcFirstFindableNight"
 ]
 
 
@@ -209,6 +210,136 @@ def _percentHandler(number, number_total):
         percent_total = np.NaN
     else:
         percent_total = 100. * number / number_total
-    
+
     return percent_total
+
+
+def firstFindableNightMinObs(obs_ids, observations,
+                             column_mapping={
+                                "obs_id": "obs_id",
+                                "night_id": "night_id"
+                             },
+                             min_obs=6):
+    """For a particular findable object, find the first night on which it
+    becomes findable when requiring a minimum of `min_obs` observations.
+
+    Parameters
+    ----------
+    obs_ids : `list`
+        List of observation IDs for this findable object
+    observations : `DataFrame`
+        Observations table
+    column_mapping : dict, optional
+        The mapping of columns in observations to internally used names.
+        Needs at least the following: "truth": ... and "obs_id" : ... . Other
+        columns may be needed for different findability metrics.
+    min_obs : int, optional
+        The minimum number of observations required for a truth to be
+        considered findable.
+
+    Returns
+    -------
+    first_findable_night : `int`
+        First night on which this object becomes findable
+    """
+    return observations.loc[obs_ids[min_obs - 1]][column_mapping["night_id"]]
+
+
+def firstFindableNightNightlyLinkages(obs_ids, observations,
+                                      column_mapping={
+                                          "obs_id": "obs_id",
+                                          "night_id": "night_id"
+                                      },
+                                      min_linkage_nights=3,
+                                      detection_window=15):
+    """For a particular findable object, find the first night on which it
+    becomes findable when requiring a minimum of `min_linkage_nights`
+    nights of linkages within a `detection_window` night range.
+
+    Parameters
+    ----------
+    obs_ids : `list`
+        List of observation IDs for this findable object
+    observations : `DataFrame`
+        Observations table
+    column_mapping : dict, optional
+        The mapping of columns in observations to internally used names.
+        Needs at least the following: "truth": ... and "obs_id" : ... . Other
+        columns may be needed for different findability metrics.
+    min_linkage_nights : int, optional
+        Minimum number of nights on which a linkage should appear.
+    detection_window : int, optional
+        Number of nights in the detection window in which a
+        minimum of `min_linkage_nights` must occur
+
+    Returns
+    -------
+    first_findable_night : `int`
+        First night on which this object becomes findable
+    """
+    # get the linkage nights from the observations table
+    linkage_nights = np.unique(observations[np.isin(observations[column_mapping["obs_id"]], obs_ids)][column_mapping["night_id"]].values)
+    diff_nights = np.diff(linkage_nights)
+
+    # compute the potential window sizes
+    window_sizes = np.array([sum(diff_nights[i:i + min_linkage_nights - 1])
+                            for i in range(len(diff_nights) - min_linkage_nights + 2)])
+
+    # check if there are no matching ones just in case it *isn't* findable
+    if not any(window_sizes <= detection_window):
+        return -1
+    else:
+        # return the night corresponding to last night in the first valid window
+        return linkage_nights[np.arange(len(window_sizes))[window_sizes <= detection_window][0] + min_linkage_nights - 1]
+
+
+def calcFirstFindableNight(findable_obs, observations,
+                           metric="min_obs",
+                           column_mapping={
+                               "obs_id": "obs_id",
+                               "night_id": "night_id"
+                           },
+                           **metric_kwargs):
+    """
+    Calculate the first night on which a truth becomes findable based
+    on the `findable_obs` table returned by `analyzeObservations`.
+
+    Parameters
+    ----------
+    observations : `~pandas.DataFrame`
+        Pandas DataFrame with at least two columns: observation IDs and the truth values
+        (the object to which the observation belongs to).
+    metric : {'min_obs', 'nightly_linkages'}
+        The desired findability metric that calculates which truths are actually findable.
+        If 'min_obs' [default]:
+            Finds all truths with a minimum of min_obs observations and the observations
+            that makes them findable.
+            See `~difi.calcFindableMinObs` for more details.
+        If 'nightly_linkages':
+            Finds the truths that have at least min_linkage_nights linkages of length
+            linkage_min_obs or more. Observations are considered to be in a possible intra-night
+            linkage if their observation time does not exceed max_obs_separation.
+            See `~difi.calcFindableNightlyLinkages` for more details.
+    column_mapping : dict, optional
+        The mapping of columns in observations to internally used names.
+        Needs at least the following: "truth": ... and "obs_id" : ... . Other
+        columns may be needed for different findability metrics.
+    **metric_kwargs
+        Any additional keyword arguments are passed to the desired findability metric. 
+        Note that column_mapping is also passed to the findability metric.
+
+    Returns
+    -------
+    first_findable_night : `pandas Series`
+        New column for `findable_obs` representing the first night
+        on which a truth becomes findable
         
+    Raises
+    ------
+    TypeError : If the truth column in observations does not have type "Object"
+    """
+    if metric == "min_obs":
+        first_findable_night = findable_obs["obs_ids"].apply(firstFindableNightMinObs, observations=observations, column_mapping=column_mapping, **metric_kwargs)
+    elif metric == "nightly_linkages":
+        first_findable_night = findable_obs["obs_ids"].apply(firstFindableNightNightlyLinkages, observations=observations, column_mapping=column_mapping, **metric_kwargs)
+    return first_findable_night


### PR DESCRIPTION
Hey @moeyensj! I've no idea if this will actually be useful to you but I was waiting for some code to run so I figured it wouldn't hurt to port across the stuff I made to a PR for difi.

The main change is to edit the `nightly_linkages` metric to additionally consider a `detection_window` of 15 nights and only mark something as findable if the other criteria are satisfied within this time frame as @mjuric suggested would be useful. This should close #33.

Additionally, I was finding it useful to know the night on which the object first became findable and to that end I added `difi.utils.calcFirstFindableNight`. I imagine this is probably not the right location but I figured you could play with it if you fancied. 

Note that all of the calculations necessary to get this first findable night are now already done in `_findNightlyLinkages` but it didn't seem like it was set up to return values in addition to obs_ids so I figured I could make it a postprocessing function instead. But perhaps it would be useful to include by default?

Hope this is helpful 😄 