### PR TITLE
Add FindabilityMetric with multiprocessing

### DIFF
--- a/difi/metrics.py
+++ b/difi/metrics.py
@@ -60,7 +60,7 @@ class FindabilityMetric(ABC):
     @staticmethod
     def _create_window_summary(
         observations: pd.DataFrame, windows: List[Tuple[int, int]], findable: List[pd.DataFrame]
-    ):
+    ) -> pd.DataFrame:
         """
         Create a summary dataframe of the windows, their start and end nights, the number of observations
         and findable truths in each window.

--- a/difi/tests/test_metrics.py
+++ b/difi/tests/test_metrics.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from ..metrics import FindabilityMetric, MinObsMetric, NightlyLinkagesMetric
 
@@ -200,3 +201,19 @@ def test_calcFindableNightlyLinkages_edge_cases(test_observations):
             findable_observations[findable_observations["truth"] == object_id]["obs_ids"].values[0],
             test_observations[test_observations["truth"] == object_id]["obs_id"].values,
         )
+
+
+def test_calcFindableNightlyLinkages_assertion(test_observations):
+    # Check that an assertion is raised if more than one object's observations
+    # are passed to the metric's determine_object_findable method
+    with pytest.raises(AssertionError):
+        metric = NightlyLinkagesMetric()
+        metric.determine_object_findable(test_observations)
+
+
+def test_calcFindableMinObs_assertion(test_observations):
+    # Check that an assertion is raised if more than one object's observations
+    # are passed to the metric's determine_object_findable method
+    with pytest.raises(AssertionError):
+        metric = MinObsMetric()
+        metric.determine_object_findable(test_observations)

--- a/difi/tests/test_metrics.py
+++ b/difi/tests/test_metrics.py
@@ -18,11 +18,18 @@ def test_FindabilityMetric__compute_windows():
     assert windows == [(1, 3), (2, 4), (3, 5), (4, 6), (5, 7), (6, 8), (7, 9), (8, 10), (9, 10)]
 
 
-def test_calcFindableMinObs(test_observations):
+@pytest.mark.parametrize(
+    "by_object",
+    [
+        True,
+        False,
+    ],
+)
+def test_calcFindableMinObs(test_observations, by_object):
 
     # All three objects should be findable
     metric = MinObsMetric(min_obs=5)
-    findable_observations, window_summary = metric.run(test_observations)
+    findable_observations, window_summary = metric.run(test_observations, by_object=by_object)
     assert len(findable_observations) == 3
 
     findable_ids = {k for k in findable_observations["truth"].values}
@@ -35,7 +42,7 @@ def test_calcFindableMinObs(test_observations):
 
     # Only two objects should be findable
     metric = MinObsMetric(min_obs=10)
-    findable_observations, window_summary = metric.run(test_observations)
+    findable_observations, window_summary = metric.run(test_observations, by_object=by_object)
 
     assert len(findable_observations) == 2
     for object_id in ["58177", "82134"]:
@@ -47,18 +54,25 @@ def test_calcFindableMinObs(test_observations):
 
     # No objects should be findable
     metric = MinObsMetric(min_obs=16)
-    findable_observations, window_summary = metric.run(test_observations)
+    findable_observations, window_summary = metric.run(test_observations, by_object=by_object)
     assert len(findable_observations) == 0
 
     return
 
 
-def test_calcFindableNightlyLinkages(test_observations):
+@pytest.mark.parametrize(
+    "by_object",
+    [
+        True,
+        False,
+    ],
+)
+def test_calcFindableNightlyLinkages(test_observations, by_object):
 
     # All three objects should be findable (each object has at least two tracklets
     # with consecutive observations no more than 2 hours apart)
     metric = NightlyLinkagesMetric(linkage_min_obs=2, max_obs_separation=2 / 24, min_linkage_nights=2)
-    findable_observations, window_summary = metric.run(test_observations)
+    findable_observations, window_summary = metric.run(test_observations, by_object=by_object)
     assert len(findable_observations) == 3
 
     findable_ids = {k for k in findable_observations["truth"].values}
@@ -109,7 +123,7 @@ def test_calcFindableNightlyLinkages(test_observations):
     # Only two objects should be findable (each object has at least three tracklets
     # with consecutive observations no more than 2 hours apart)
     metric = NightlyLinkagesMetric(linkage_min_obs=2, max_obs_separation=2 / 24, min_linkage_nights=3)
-    findable_observations, window_summary = metric.run(test_observations)
+    findable_observations, window_summary = metric.run(test_observations, by_object=by_object)
     assert len(findable_observations) == 2
 
     findable_ids = {k for k in findable_observations["truth"].values}
@@ -147,7 +161,7 @@ def test_calcFindableNightlyLinkages(test_observations):
     # Only one object should be findable (this object has at least two tracklets
     # with at least 3 consecutive observations no more than 2 hours apart)
     metric = NightlyLinkagesMetric(linkage_min_obs=3, max_obs_separation=2 / 24, min_linkage_nights=2)
-    findable_observations, window_summary = metric.run(test_observations)
+    findable_observations, window_summary = metric.run(test_observations, by_object=by_object)
     assert len(findable_observations) == 1
 
     findable_ids = {k for k in findable_observations["truth"].values}

--- a/difi/tests/test_metrics_benchmarks.py
+++ b/difi/tests/test_metrics_benchmarks.py
@@ -21,6 +21,23 @@ def test_benchmark_calcFindableMinObs(benchmark, test_observations, min_obs):
 
 
 @pytest.mark.parametrize(
+    "min_obs",
+    [
+        5,
+        10,
+        20,
+    ],
+)
+@pytest.mark.benchmark(group="metrics_min_obs")
+def test_benchmark_calcFindableMinObs_by_object(benchmark, test_observations, min_obs):
+
+    metric = MinObsMetric(min_obs=min_obs)
+    benchmark(metric.run, test_observations, by_object=True)
+
+    return
+
+
+@pytest.mark.parametrize(
     ["linkage_min_obs", "max_obs_separation", "min_linkage_nights"],
     [
         (2, 2 / 24, 2),
@@ -45,4 +62,29 @@ def test_benchmark_calcFindableNightlyLinkages(
         metric.run,
         test_observations,
     )
+    return
+
+
+@pytest.mark.parametrize(
+    ["linkage_min_obs", "max_obs_separation", "min_linkage_nights"],
+    [
+        (2, 2 / 24, 2),
+        (2, 4 / 24, 3),
+        (3, 2 / 24, 2),
+        (3, 4 / 24, 3),
+        (4, 2 / 24, 2),
+        (4, 4 / 24, 3),
+    ],
+)
+@pytest.mark.benchmark(group="metrics_tracklets")
+def test_benchmark_calcFindableNightlyLinkages_by_object(
+    benchmark, test_observations, linkage_min_obs, max_obs_separation, min_linkage_nights
+):
+
+    metric = NightlyLinkagesMetric(
+        linkage_min_obs=linkage_min_obs,
+        max_obs_separation=max_obs_separation,
+        min_linkage_nights=min_linkage_nights,
+    )
+    benchmark(metric.run, test_observations, by_object=True)
     return

--- a/difi/tests/test_metrics_benchmarks.py
+++ b/difi/tests/test_metrics_benchmarks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..metrics import calcFindableMinObs, calcFindableNightlyLinkages
+from ..metrics import MinObsMetric, NightlyLinkagesMetric
 
 
 @pytest.mark.parametrize(
@@ -14,7 +14,8 @@ from ..metrics import calcFindableMinObs, calcFindableNightlyLinkages
 @pytest.mark.benchmark(group="metrics_min_obs")
 def test_benchmark_calcFindableMinObs(benchmark, test_observations, min_obs):
 
-    benchmark(calcFindableMinObs, test_observations, min_obs=min_obs)
+    metric = MinObsMetric(min_obs=min_obs)
+    benchmark(metric.run, test_observations)
 
     return
 
@@ -35,11 +36,13 @@ def test_benchmark_calcFindableNightlyLinkages(
     benchmark, test_observations, linkage_min_obs, max_obs_separation, min_linkage_nights
 ):
 
-    benchmark(
-        calcFindableNightlyLinkages,
-        test_observations,
+    metric = NightlyLinkagesMetric(
         linkage_min_obs=linkage_min_obs,
         max_obs_separation=max_obs_separation,
         min_linkage_nights=min_linkage_nights,
+    )
+    benchmark(
+        metric.run,
+        test_observations,
     )
     return


### PR DESCRIPTION
Current benchmark results for a small dataset: 

With multiprocessing (`num_jobs = 1`):
![Screenshot from 2023-04-30 15-57-43](https://user-images.githubusercontent.com/4206654/235379970-f1795cea-ef4f-4c31-8164-99dbe26e59f7.png)

With multiprocessing (`num_jobs = None`) (not beating the overhead of setting up a pool since the test data is small):
 ![Screenshot from 2023-04-30 15-58-33](https://user-images.githubusercontent.com/4206654/235379990-198531a7-4620-4d9d-b061-36ef14de36da.png)

