### PR TITLE
Set id-token: write in pip publish workflow

### DIFF
--- a/.github/workflows/pip-publish.yml
+++ b/.github/workflows/pip-publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
     - name: Checkout Repository
@@ -22,5 +24,3 @@ jobs:
       run: python -m build --sdist --wheel --outdir dist/ .
     - name: Publish difi to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
I've also issues a new auth token for the conda workflow. 