### PR TITLE
Add CI tests for Python 3.8, 3.11 

### DIFF
--- a/.github/workflows/conda-build-lint-test.yml
+++ b/.github/workflows/conda-build-lint-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/conda-build-lint-test.yml
+++ b/.github/workflows/conda-build-lint-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/pip-build-lint-test-coverage.yml
+++ b/.github/workflows/pip-build-lint-test-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/pip-build-lint-test-coverage.yml
+++ b/.github/workflows/pip-build-lint-test-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # difi
 Did I Find It?  
 
-[![Python 3.7+](https://img.shields.io/badge/Python-3.7%2B-blue)](https://img.shields.io/badge/Python-3.7%2B-blue)
+[![Python 3.8+](https://img.shields.io/badge/Python-3.8%2B-blue)](https://img.shields.io/badge/Python-3.8%2B-blue)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![DOI](https://zenodo.org/badge/152989392.svg)](https://zenodo.org/badge/latestdoi/152989392)  
 [![docker - Build, Lint, and Test](https://github.com/moeyensj/difi/actions/workflows/docker-build-lint-test.yml/badge.svg)](https://github.com/moeyensj/difi/actions/workflows/docker-build-lint-test.yml)

--- a/difi/utils.py
+++ b/difi/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-def _checkColumnTypes(df: pd.DataFrame, cols: list):
+def _checkColumnTypes(df: pd.DataFrame, cols: List[str]):
     """
     Checks that each dataframe column listed in cols has Pandas dtype "Object".
 
@@ -51,7 +51,7 @@ def _checkColumnTypes(df: pd.DataFrame, cols: list):
     return
 
 
-def _checkColumnTypesEqual(df1: pd.DataFrame, df2: pd.DataFrame, cols: list):
+def _checkColumnTypesEqual(df1: pd.DataFrame, df2: pd.DataFrame, cols: List[str]):
     """
     Checks that each column listed in cols have the same Pandas dtype in df1 and df2.
 
@@ -88,7 +88,9 @@ def _checkColumnTypesEqual(df1: pd.DataFrame, df2: pd.DataFrame, cols: list):
     return
 
 
-def _classHandler(classes: Union[str, dict, None], dataframe: pd.DataFrame):
+def _classHandler(
+    classes: Union[str, dict, None], dataframe: pd.DataFrame
+) -> Tuple[List[str], List[List[str]]]:
     """
     Tests that the `classes` keyword argument is defined correctly.
     `classes` should one of the following:
@@ -212,11 +214,12 @@ def _percentHandler(number: float, number_total: float) -> float:
 
 
 def _firstFindableNightMinObs(
-    obs_ids: list[str],
+    obs_ids: List[str],
     observations: pd.DataFrame,
     min_obs: int = 6,
 ) -> int:
-    """For a particular findable object, find the first night on which it
+    """
+    For a particular findable object, find the first night on which it
     becomes findable when requiring a minimum of `min_obs` observations.
 
     Parameters
@@ -238,12 +241,13 @@ def _firstFindableNightMinObs(
 
 
 def _firstFindableNightNightlyLinkages(
-    obs_ids: list[str],
+    obs_ids: List[str],
     observations: pd.DataFrame,
     min_linkage_nights: int = 3,
     detection_window: int = 15,
 ) -> int:
-    """For a particular findable object, find the first night on which it
+    """
+    For a particular findable object, find the first night on which it
     becomes findable when requiring a minimum of `min_linkage_nights`
     nights of linkages within a `detection_window` night range.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,14 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "numba",
     "numpy",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,13 +9,13 @@ source:
 
 requirements:
   host:
-    - python >=3.7.1
+    - python >=3.8
     - pip
     - setuptools >=45
     - wheel
     - setuptools_scm >=6.0
   run:
-    - python >=3.7.1
+    - python >=3.8
     - numba
     - numpy
     - pandas


### PR DESCRIPTION
Adds Python versions 3.8 and 3.11 to the CI workflows to increase test coverage. This PR bumps the minimum version of Python to 3.8 because `difi` uses `multiprocessing.shared_memory` and also fixes some type annotation issues for older versions of Python.  