### PR TITLE
Store observations in shared memory specific to instance

### DIFF
--- a/difi/metrics.py
+++ b/difi/metrics.py
@@ -574,8 +574,18 @@ class FindabilityMetric(ABC):
         return
 
     def _clear_shared_record_array(self):
+        """
+        Clears the shared memory array for this instance of the metric.
+
+        Returns
+        -------
+        None
+        """
         shared_mem = shared_memory.SharedMemory(self._shared_memory_name)
         shared_mem.unlink()
+        self._shared_memory_name = None
+        self._num_observations = 0
+        self._dtypes = None
 
     def _run_object_worker(
         self,


### PR DESCRIPTION
Instead of storing the observations in shared memory with a constant name (`"DIFI_ARRAY"`), store observations in shared memory specific to the instance of the metric (`"DIFI_ARRAY_{os.getpid()}"`).

Also adds a keyword argument to `FindabilityMetric.run` that allows the user to decide if shared memory should be cleared or not on failure.